### PR TITLE
(BKR-1190) Adds new vagrant provider for vmware_desktop

### DIFF
--- a/lib/beaker/hypervisor/vagrant_desktop.rb
+++ b/lib/beaker/hypervisor/vagrant_desktop.rb
@@ -1,0 +1,13 @@
+require 'beaker/hypervisor/vagrant'
+
+class Beaker::VagrantDesktop < Beaker::Vagrant
+  def provision(provider = 'vmware_desktop')
+    super
+  end
+
+  def self.provider_vfile_section(host, options)
+    "    v.vm.provider :vmware_desktop do |v|\n" +
+      "      v.vmx['memsize'] = '#{memsize(host,options)}'\n" +
+      "    end\n"
+  end
+end

--- a/lib/beaker/hypervisor/vagrant_desktop.rb
+++ b/lib/beaker/hypervisor/vagrant_desktop.rb
@@ -1,7 +1,7 @@
 require 'beaker/hypervisor/vagrant'
 
 class Beaker::VagrantDesktop < Beaker::Vagrant
-  def provision(provider = 'vmware_desktop')
+  def provision(provider = 'vmware_workstation')
     super
   end
 

--- a/spec/beaker/hypervisor/vagrant_desktop_spec.rb
+++ b/spec/beaker/hypervisor/vagrant_desktop_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+describe Beaker::VagrantDesktop do
+  let( :options ) { make_opts.merge({ :hosts_file => 'sample.cfg', 'logger' => double().as_null_object }) }
+  let( :vagrant ) { Beaker::VagrantDesktop.new( @hosts, options ) }
+
+  before :each do
+    @hosts = make_hosts()
+  end
+
+  it "uses the vmware_desktop provider for provisioning" do
+    @hosts.each do |host|
+      host_prev_name = host['user']
+      expect( vagrant ).to receive( :set_ssh_config ).with( host, 'vagrant' ).once
+      expect( vagrant ).to receive( :copy_ssh_to_root ).with( host, options ).once
+      expect( vagrant ).to receive( :set_ssh_config ).with( host, host_prev_name ).once
+    end
+    expect( vagrant ).to receive( :hack_etc_hosts ).with( @hosts, options ).once
+    expect( vagrant ).to receive( :vagrant_cmd ).with( "up --provider vmware_desktop" ).once
+    vagrant.provision
+  end
+
+  it "can make a Vagranfile for a set of hosts" do
+    path = vagrant.instance_variable_get( :@vagrant_path )
+    allow( vagrant ).to receive( :randmac ).and_return( "0123456789" )
+
+    vagrant.make_vfile( @hosts )
+
+    vagrantfile = File.read( File.expand_path( File.join( path, "Vagrantfile")))
+    expect( vagrantfile ).to include( %Q{    v.vm.provider :vmware_desktop do |v|\n      v.vmx['memsize'] = '1024'\n    end})
+  end
+end

--- a/spec/beaker/hypervisor/vagrant_desktop_spec.rb
+++ b/spec/beaker/hypervisor/vagrant_desktop_spec.rb
@@ -16,7 +16,7 @@ describe Beaker::VagrantDesktop do
       expect( vagrant ).to receive( :set_ssh_config ).with( host, host_prev_name ).once
     end
     expect( vagrant ).to receive( :hack_etc_hosts ).with( @hosts, options ).once
-    expect( vagrant ).to receive( :vagrant_cmd ).with( "up --provider vmware_desktop" ).once
+    expect( vagrant ).to receive( :vagrant_cmd ).with( "up --provider vmware_workstation" ).once
     vagrant.provision
   end
 


### PR DESCRIPTION
In latest release of vagrant the vmware_workstation provider was
renamed to vmware_desktop so adding new provider.

CC @tragiccode @kevpl @glennsarti 