### PR TITLE
dont reset RUBYLIB

### DIFF
--- a/lib/beaker/hypervisor/vagrant.rb
+++ b/lib/beaker/hypervisor/vagrant.rb
@@ -166,7 +166,7 @@ module Beaker
       @vagrant_path = File.expand_path(File.join(File.basename(__FILE__), '..', '.vagrant', 'beaker_vagrant_files', File.basename(options[:hosts_file])))
       FileUtils.mkdir_p(@vagrant_path)
       @vagrant_file = File.expand_path(File.join(@vagrant_path, "Vagrantfile"))
-      @vagrant_env = { "RUBYLIB" => "" }
+      @vagrant_env = { }
     end
 
     def provision(provider = nil)


### PR DESCRIPTION
Hi puppetlabs,

I have been trying to debug an issues using using vagrant-beaker and think i have tracked down the problem however suspect the fix is gonna break something else.   The problem im having relates to some acceptance tests using beaker, vagrant, virtualbox and a freebsd image.  The error i get is as follows

```bash
/usr/local/rvm/rubies/ruby-2.3.3/bin/ruby -I/home/gitlab-runner/puppet-openbgpd/vendor/bundle/ruby/2.3.0/gems/rspec-core-3.6.0/lib:/home/gitlab-runner/puppet-openbgpd/vendor/bundle/ruby/2.3.0/gems/rspec-support-3.6.0/lib /home/gitlab-runner/puppet-openbgpd/vendor/bundle/ruby/2.3.0/gems/rspec-core-3.6.0/exe/rspec spec/acceptance/06_multi_peers_spec.rb --color
/home/gitlab-runner/puppet-openbgpd/vendor/bundle/ruby/2.3.0/gems/beaker-rspec-6.1.0/lib/beaker-rspec/helpers/serverspec.rb:43: warning: already initialized constant Module::VALID_OPTIONS_KEYS
/home/gitlab-runner/puppet-openbgpd/vendor/bundle/ruby/2.3.0/gems/specinfra-2.71.2/lib/specinfra/configuration.rb:4: warning: previous definition of VALID_OPTIONS_KEYS was here
Hypervisor for router1 is vagrant
Hypervisor for router2 is vagrant
Hypervisor for router3 is vagrant
Beaker::Hypervisor, found some vagrant boxes to create

Beaker failed to destroy the existing VM's. If you think this is
an error or you upgraded from an older version of beaker try
verifying the VM exists and deleting the existing Vagrantfile if
you believe it is safe to do so. WARNING: If a VM still exists
please run 'vagrant destroy'.

cd /home/gitlab-runner/puppet-openbgpd/.vagrant/beaker_vagrant_files/freebsd-multi-10.3.yml
vagrant status
vagrant destroy # only need to run this is a VM is not created
rm /home/gitlab-runner/puppet-openbgpd/.vagrant/beaker_vagrant_files/freebsd-multi-10.3.yml/Vagrantfile # only do this if all VM's are actually destroyed

An error occurred while loading ./spec/acceptance/06_multi_peers_spec.rb.
Failure/Error: require 'beaker-rspec'
RuntimeError:
  Failed to exec 'vagrant destroy --force'. Error was /usr/local/rvm/rubies/ruby-2.3.3/lib/ruby/site_ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require': cannot load such file -- bundler/setup (LoadError)
  	from /usr/local/rvm/rubies/ruby-2.3.3/lib/ruby/site_ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'

# ./vendor/bundle/ruby/2.3.0/gems/beaker-vagrant-0.1.0/lib/beaker/hypervisor/vagrant.rb:251:in `block (2 levels) in vagrant_cmd'
# ./vendor/bundle/ruby/2.3.0/gems/beaker-vagrant-0.1.0/lib/beaker/hypervisor/vagrant.rb:246:in `block in vagrant_cmd'
# ./vendor/bundle/ruby/2.3.0/gems/beaker-vagrant-0.1.0/lib/beaker/hypervisor/vagrant.rb:244:in `chdir'
# ./vendor/bundle/ruby/2.3.0/gems/beaker-vagrant-0.1.0/lib/beaker/hypervisor/vagrant.rb:244:in `vagrant_cmd'
# ./vendor/bundle/ruby/2.3.0/gems/beaker-vagrant-0.1.0/lib/beaker/hypervisor/vagrant.rb:180:in `provision'
# ./vendor/bundle/ruby/2.3.0/gems/beaker-3.24.0/lib/beaker/hypervisor.rb:41:in `create'
# ./vendor/bundle/ruby/2.3.0/gems/beaker-3.24.0/lib/beaker/network_manager.rb:73:in `block in provision'
# ./vendor/bundle/ruby/2.3.0/gems/beaker-3.24.0/lib/beaker/network_manager.rb:72:in `each_key'
# ./vendor/bundle/ruby/2.3.0/gems/beaker-3.24.0/lib/beaker/network_manager.rb:72:in `provision'
# ./vendor/bundle/ruby/2.3.0/gems/beaker-rspec-6.1.0/lib/beaker-rspec/beaker_shim.rb:35:in `provision'
# ./vendor/bundle/ruby/2.3.0/gems/beaker-rspec-6.1.0/lib/beaker-rspec/spec_helper.rb:46:in `block in <top (required)>'
# ./vendor/bundle/ruby/2.3.0/gems/beaker-rspec-6.1.0/lib/beaker-rspec/spec_helper.rb:5:in `<top (required)>'
# ./vendor/bundle/ruby/2.3.0/gems/beaker-rspec-6.1.0/lib/beaker-rspec.rb:5:in `require'
# ./vendor/bundle/ruby/2.3.0/gems/beaker-rspec-6.1.0/lib/beaker-rspec.rb:5:in `<module:BeakerRSpec>'
# ./vendor/bundle/ruby/2.3.0/gems/beaker-rspec-6.1.0/lib/beaker-rspec.rb:1:in `<top (required)>'
# ./spec/spec_helper_acceptance.rb:3:in `require'
# ./spec/spec_helper_acceptance.rb:3:in `<top (required)>'
# ./spec/acceptance/06_multi_peers_spec.rb:3:in `require'
# ./spec/acceptance/06_multi_peers_spec.rb:3:in `<top (required)>'
No examples found.

Finished in 0.00031 seconds (files took 1.24 seconds to load)
0 examples, 0 failures, 1 error occurred outside of examples

/usr/local/rvm/rubies/ruby-2.3.3/bin/ruby -I/home/gitlab-runner/puppet-openbgpd/vendor/bundle/ruby/2.3.0/gems/rspec-core-3.6.0/lib:/home/gitlab-runner/puppet-openbgpd/vendor/bundle/ruby/2.3.0/gems/rspec-support-3.6.0/lib /home/gitlab-runner/puppet-openbgpd/vendor/bundle/ruby/2.3.0/gems/rspec-core-3.6.0/exe/rspec spec/acceptance/06_multi_peers_spec.rb --color failed
```

and can be recreated with the following commands (on a clean linux machine)
```bash
$ git clone https://github.com/icann-dns/puppet-openbgpd
$ cd puppet-openbgpd
$ git checkout add_rejected_routes
$ bundle install --path=${BUNDLE_PATH:-vendor/bundle}
$ BEAKER_destroy=no BEAKER_set=freebsd-multi-10.3 BEAKER_debug=yes bundle exec rake beaker SPEC=spec/acceptance/06_multi_peers_spec.rb
```

It appears that when `vagrant_cmd` is called it shells out to `vagrant-wrapper`.  however when it does this is clears the `RUBYLIB` environment variable.  which leaves `$:` being set to the following when 

```
/usr/lib/ruby/site_ruby/2.4.0
/usr/lib/ruby/site_ruby/2.4.0/x86_64-linux
/usr/lib/ruby/site_ruby
/usr/lib/ruby/vendor_ruby/2.4.0
/usr/lib/ruby/vendor_ruby/2.4.0/x86_64-linux
/usr/lib/ruby/vendor_ruby
/usr/lib/ruby/2.4.0
/usr/lib/ruby/2.4.0/x86_64-linux
```

and none of these have the bundler which is why the command fails

```bash
$ locate bundler/setup.rb                        
/home/jbond/.gem/ruby/2.4.0/gems/bundler-1.15.4/lib/bundler/setup.rb
/home/jbond/git/puppet-openbgpd/vendor/bundle/bundler/setup.rb
/usr/lib/ruby/gems/2.4.0/gems/bundler-1.15.4/lib/bundler/setup.rb
```

Sorry for the long post and more then hapopy to try other solutions if you can recomend something

Thanks