### PR TITLE
(BKR-1237)set vm.base_mac for freebsd in Vagrantfile

### DIFF
--- a/lib/beaker/hypervisor/vagrant.rb
+++ b/lib/beaker/hypervisor/vagrant.rb
@@ -23,11 +23,14 @@ module Beaker
       private_network_string = "    v.vm.network :private_network, ip: \"#{host['ip'].to_s}\", :netmask => \"#{host['netmask'] ||= "255.255.0.0"}\""
       case host['network_mac']
       when 'false'
+        @mac = randmac
         private_network_string << "\n"
       when nil
-        private_network_string << ", :mac => \"#{randmac}\"\n"
+        @mac = randmac
+        private_network_string << ", :mac => \"#{@mac}\"\n"
       else
-        private_network_string << ", :mac => \"#{host['network_mac']}\"\n"
+        @mac = host['network_mac']
+        private_network_string << ", :mac => \"#{@mac}\"\n"
       end
     end
 
@@ -103,6 +106,7 @@ module Beaker
           else
             v_file << "    v.vm.synced_folder '.', '/vagrant', :nfs => true\n"
           end
+          v_file << "    v.vm.base_mac = '#{@mac}'\n"
         end
 
         v_file << self.class.provider_vfile_section(host, options)

--- a/spec/beaker/hypervisor/vagrant_spec.rb
+++ b/spec/beaker/hypervisor/vagrant_spec.rb
@@ -187,6 +187,30 @@ EOF
       end
     end
 
+    context 'when generating a freebsd config' do
+      before do
+        path = vagrant.instance_variable_get( :@vagrant_path )
+        allow( vagrant ).to receive( :randmac ).and_return( "0123456789" )
+        @hosts[0][:platform] = 'freebsd'
+
+        vagrant.make_vfile( @hosts )
+
+        @generated_file = File.read( File.expand_path( File.join( path, "Vagrantfile") ) )
+      end
+
+      it 'has the proper ssh shell' do
+        expect( @generated_file ).to match /v.ssh.shell = 'sh'\n/
+      end
+
+      it 'has the proper guest setting' do
+        expect( @generated_file ).to match /v.vm.guest = :freebsd\n/
+      end
+
+      it 'sets the vm.base_mac setting' do
+        expect( @generated_file ).to match /v.vm.base_mac = '0123456789'\n/
+      end
+    end
+
     it "uses the memsize defined per vagrant host" do
       path = vagrant.instance_variable_get( :@vagrant_path )
       allow( vagrant ).to receive( :randmac ).and_return( "0123456789" )


### PR DESCRIPTION
FreeBSD needs the MAC address of the VM in the Vagrantfile. Upstream
issue is https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=201904
Beaker issue is https://tickets.puppetlabs.com/browse/BKR-1237