### PR TITLE
(BKR-1264) Ensure vm.hostname is legal

### DIFF
--- a/lib/beaker/hypervisor/vagrant.rb
+++ b/lib/beaker/hypervisor/vagrant.rb
@@ -39,6 +39,7 @@ module Beaker
       v_file << "  c.ssh.insert_key = false\n"
 
       hosts.each do |host|
+        host.name.tr!('_','-') # Rewrite Hostname with hyphens instead of underscores to get legal hostname
         host['ip'] ||= randip #use the existing ip, otherwise default to a random ip
         v_file << "  c.vm.define '#{host.name}' do |v|\n"
         v_file << "    v.vm.hostname = '#{host.name}'\n"

--- a/spec/beaker/hypervisor/vagrant_spec.rb
+++ b/spec/beaker/hypervisor/vagrant_spec.rb
@@ -106,6 +106,18 @@ EOF
       expect( vagrantfile ).to match(/(ssh.forward_agent = true)/)
     end
 
+    it "can replace underscores in host.name with hypens" do
+      path = vagrant.instance_variable_get( :@vagrant_path )
+      allow( vagrant ).to receive( :randmac ).and_return( "0123456789" )
+
+      host = make_host( 'name-with_underscore', {} ) 
+      vagrant.make_vfile( [host,], options )
+
+      vagrantfile = File.read( File.expand_path( File.join( path, "Vagrantfile")))
+      expect( vagrantfile ).to match(/v.vm.hostname = .*name-with-underscore/)
+
+    end
+
     it "can make a Vagrantfile with synced_folder disabled" do
       path = vagrant.instance_variable_get( :@vagrant_path )
       allow( vagrant ).to receive( :randmac ).and_return( "0123456789" )


### PR DESCRIPTION
Some of the newer beaker-hosgenerator definitions contain underscores
which are illegal as hostnames, preventing vagrant configuring and
bringing up a machine (e.g. windows2012r2_ja-64-1). vmpooler for example
doesn't have a problem with this as the the actual hostname is obtained
from the vmpooler API, whereas beaker-vagrant re-uses the hostname
directly.

Translate any underscores in host.name to hyphens to ensure a legal
hostname.