### PR TITLE
Bugfix: Issue with user given invalid keys for synced folders

### DIFF
--- a/lib/beaker/hypervisor/vagrant.rb
+++ b/lib/beaker/hypervisor/vagrant.rb
@@ -3,6 +3,7 @@ require 'open3'
 module Beaker
   class Vagrant < Beaker::Hypervisor
 
+    require 'beaker/hypervisor/vagrant/mount_folder'
     require 'beaker/hypervisor/vagrant_virtualbox'
     # Return a random mac address
     #
@@ -53,8 +54,9 @@ module Beaker
 
         unless host['mount_folders'].nil?
           host['mount_folders'].each do |name, folder|
-            unless folder[:from].nil? or folder[:to].nil?
-              v_file << "    v.vm.synced_folder '#{folder[:from]}', '#{folder[:to]}', create: true\n"
+            mount_folder = Vagrant::MountFolder.new(name, folder)
+            if mount_folder.required_keys_present?
+              v_file << "    v.vm.synced_folder '#{mount_folder.from}', '#{mount_folder.to}', create: true\n"
             else
               @logger.warn "Using 'mount_folders' requires options 'from' and 'to' for vagrant node, given #{folder.inspect}"
             end

--- a/lib/beaker/hypervisor/vagrant.rb
+++ b/lib/beaker/hypervisor/vagrant.rb
@@ -53,7 +53,11 @@ module Beaker
 
         unless host['mount_folders'].nil?
           host['mount_folders'].each do |name, folder|
-            v_file << "    v.vm.synced_folder '#{folder[:from]}', '#{folder[:to]}', create: true\n"
+            unless folder[:from].nil? or folder[:to].nil?
+              v_file << "    v.vm.synced_folder '#{folder[:from]}', '#{folder[:to]}', create: true\n"
+            else
+              @logger.warn "Using 'mount_folders' requires options 'from' and 'to' for vagrant node, given #{folder.inspect}"
+            end
           end
         end
 

--- a/lib/beaker/hypervisor/vagrant/mount_folder.rb
+++ b/lib/beaker/hypervisor/vagrant/mount_folder.rb
@@ -1,0 +1,20 @@
+module Beaker
+  class Vagrant::MountFolder
+    def initialize(name, spec)
+      @name = name
+      @spec = spec
+    end
+
+    def required_keys_present?
+      not from.nil? and not to.nil?
+    end
+
+    def from
+      @spec[:from]
+    end
+
+    def to
+      @spec[:to]
+    end
+  end
+end

--- a/spec/beaker/hypervisor/vagrant_spec.rb
+++ b/spec/beaker/hypervisor/vagrant_spec.rb
@@ -110,7 +110,7 @@ EOF
       path = vagrant.instance_variable_get( :@vagrant_path )
       allow( vagrant ).to receive( :randmac ).and_return( "0123456789" )
 
-      host = make_host( 'name-with_underscore', {} ) 
+      host = make_host( 'name-with_underscore', {} )
       vagrant.make_vfile( [host,], options )
 
       vagrantfile = File.read( File.expand_path( File.join( path, "Vagrantfile")))
@@ -157,6 +157,25 @@ EOF
 
       vagrantfile = File.read( File.expand_path( File.join( path, "Vagrantfile")))
       expect( vagrantfile ).to match(/v.vm.network :private_network, ip: "ip.address.for.vm1", :netmask => "255.255.0.0"/)
+    end
+
+    it "can make a Vagrantfile with inproper keys for synced folders" do
+      path = vagrant.instance_variable_get( :@vagrant_path )
+
+      hosts = make_hosts({:mount_folders => {
+        :test_invalid1 => {:host_path => '/invalid1', :container_path => '/invalid1'},
+        :test_invalid2 => {:from => '/invalid2', :container_path => '/invalid2'},
+        :test_invalid3 => {:host_path => '/invalid3', :to => '/invalid3'},
+        :test_valid => {:from => '/valid', :to => '/valid'}
+      }},1)
+      vagrant.make_vfile( hosts, options )
+
+      vagrantfile = File.read( File.expand_path( File.join( path, "Vagrantfile")))
+
+      expect( vagrantfile ).not_to match(/v.vm.synced_folder '', '', create: true/)
+      expect( vagrantfile ).not_to match(/v.vm.synced_folder '\/invalid2', '', create: true/)
+      expect( vagrantfile ).not_to match(/v.vm.synced_folder '', '\/invalid3', create: true/)
+      expect( vagrantfile ).to match(/v.vm.synced_folder '\/valid', '\/valid', create: true/)
     end
 
     context "when generating a windows config" do

--- a/spec/beaker/hypervisor/vagrant_spec.rb
+++ b/spec/beaker/hypervisor/vagrant_spec.rb
@@ -159,7 +159,7 @@ EOF
       expect( vagrantfile ).to match(/v.vm.network :private_network, ip: "ip.address.for.vm1", :netmask => "255.255.0.0"/)
     end
 
-    it "can make a Vagrantfile with inproper keys for synced folders" do
+    it "can make a Vagrantfile with improper keys for synced folders" do
       path = vagrant.instance_variable_get( :@vagrant_path )
 
       hosts = make_hosts({:mount_folders => {


### PR DESCRIPTION
Fixing issue with user given invalid keys for synced folders for ex.: copy-paste from docker nodeset.