### PR TITLE
Add support for alternate volume storage controllers

### DIFF
--- a/docs/vagrant.md
+++ b/docs/vagrant.md
@@ -160,7 +160,7 @@ In the above, beaker will forward port 10080 and 8080 on the Host to port 80 and
 
 ### Volumes Support
 
-When using the Vagrant Hypervisor, beaker can create attached volumes which appear as extra disks on the guest. The size of the volume should be specified in megabytes.
+When using the Vagrant Hypervisor, beaker can create attached volumes which appear as extra disks on the guest. The size of the volume should be specified in megabytes. You can override the type of storage controller used to attach the disk by specifying `volume_storage_controller` with values of `AHCI`, `LSILogic`, `USB`, or `PIIX4`.
 
 **Example hosts file**
 
@@ -178,6 +178,7 @@ When using the Vagrant Hypervisor, beaker can create attached volumes which appe
         volumes:
           second_disk:
             size: 5120
+        volume_storage_controller: USB
 
 # vagrant plugins #
 


### PR DESCRIPTION
You might have to bare with me on this one! 

This PR adds support for changing the type of storage controller that is added by beaker-vagrant when using the "volumes" support. This is necessary because not all vagrant boxes support IntelAHCI (the type that beaker-vagrant was using). 

This PR adds support for LSILogic, PIIX, USB and retains the existing support for IntelAHCI. If you select USB as the controller type, it also ensures that USB is enabled on the VM (without enabling EHCI or XHCI, both of which may require a license from Oracle for the extension pack if you use them).

It also adds some unit tests for volumes support. I'd love to add some integration tests for this too, but that started to blow my mind, and there are currently none for "volumes" anyway.