### PR TITLE
BKR-1508

### DIFF
--- a/docs/vagrant.md
+++ b/docs/vagrant.md
@@ -188,6 +188,29 @@ When using the Vagrant Hypervisor, beaker can create attached volumes which appe
             size: 5120
         volume_storage_controller: USB
 
+### Adding vagrant shell provisioner
+
+When using the Vagrant Hypervisor, beaker can create the Vagrantfile with a shell provisioner. This is done by using the `shell_provisioner` option in the nodeset file.
+
+**Example hosts file**
+
+    HOSTS:
+      ubuntu-1404-x64-master:
+        roles:
+          - master
+          - agent
+          - dashboard
+          - database
+        platform: ubuntu-1404-x86_64
+        hypervisor: vagrant
+        box: puppetlabs/ubuntu-14.04-64-nocm
+        box_url: https://vagrantcloud.com/puppetlabs/boxes/ubuntu-14.04-64-nocm
+        ip: 192.168.20.20
+        shell_provisioner:
+          path: /home/user/scripts/bootstrap.sh
+
+In the above, beaker will create a Vagrantfile which runs the above shell script on the Agent guest.
+
 # vagrant plugins #
 
 You can check more information for some suported vagrant plugins:

--- a/lib/beaker/hypervisor/vagrant.rb
+++ b/lib/beaker/hypervisor/vagrant.rb
@@ -159,6 +159,11 @@ module Beaker
 
         #set the user
         ssh_config = ssh_config.gsub(/User vagrant/, "User #{user}")
+
+        if @options[:forward_ssh_agent] == true
+          ssh_config = ssh_config.gsub(/IdentitiesOnly yes/, "IdentitiesOnly no")
+        end
+
         f.write(ssh_config)
         f.rewind
         host['ssh'] = {:config => f.path()}

--- a/lib/beaker/hypervisor/vagrant.rb
+++ b/lib/beaker/hypervisor/vagrant.rb
@@ -35,6 +35,15 @@ module Beaker
       end
     end
 
+    def shell_provisioner_generator(provisioner_config)
+      unless provisioner_config['path'].nil? || provisioner_config['path'].empty?
+        shell_provisioner_string = "    v.vm.provision 'shell', :path => '#{provisioner_config['path']}'\n"
+        shell_provisioner_string
+      else
+        raise "No path defined for shell_provisioner or path empty"
+      end
+    end
+
     def make_vfile hosts, options = {}
       #HACK HACK HACK - add checks here to ensure that we have box + box_url
       #generate the VagrantFile
@@ -53,6 +62,8 @@ module Beaker
         v_file << "    v.vm.box_download_insecure = '#{host['box_download_insecure']}'\n" unless host['box_download_insecure'].nil?
         v_file << "    v.vm.box_check_update = '#{host['box_check_update'] ||= 'true'}'\n"
         v_file << "    v.vm.synced_folder '.', '/vagrant', disabled: true\n" if host['synced_folder'] == 'disabled'
+        v_file << "    v.vm.provision 'shell', :path => '#{host['shell_provisioner']['path']}'\n" unless host['shell_provisioner'].nil?
+        v_file << shell_provisioner_generator(host['shell_provisioner']) if host['shell_provisioner']
         v_file << private_network_generator(host)
 
         unless host['mount_folders'].nil?

--- a/lib/beaker/hypervisor/vagrant.rb
+++ b/lib/beaker/hypervisor/vagrant.rb
@@ -37,7 +37,11 @@ module Beaker
 
     def shell_provisioner_generator(provisioner_config)
       unless provisioner_config['path'].nil? || provisioner_config['path'].empty?
-        shell_provisioner_string = "    v.vm.provision 'shell', :path => '#{provisioner_config['path']}'\n"
+        unless provisioner_config['args'].nil?
+          shell_provisioner_string = "    v.vm.provision 'shell', :path => '#{provisioner_config['path']}', :args => '#{provisioner_config['args']}' \n"
+        else
+          shell_provisioner_string = "    v.vm.provision 'shell', :path => '#{provisioner_config['path']}'\n"
+        end
         shell_provisioner_string
       else
         raise "No path defined for shell_provisioner or path empty"
@@ -62,7 +66,6 @@ module Beaker
         v_file << "    v.vm.box_download_insecure = '#{host['box_download_insecure']}'\n" unless host['box_download_insecure'].nil?
         v_file << "    v.vm.box_check_update = '#{host['box_check_update'] ||= 'true'}'\n"
         v_file << "    v.vm.synced_folder '.', '/vagrant', disabled: true\n" if host['synced_folder'] == 'disabled'
-        v_file << "    v.vm.provision 'shell', :path => '#{host['shell_provisioner']['path']}'\n" unless host['shell_provisioner'].nil?
         v_file << shell_provisioner_generator(host['shell_provisioner']) if host['shell_provisioner']
         v_file << private_network_generator(host)
 

--- a/spec/beaker/hypervisor/vagrant_spec.rb
+++ b/spec/beaker/hypervisor/vagrant_spec.rb
@@ -194,6 +194,24 @@ EOF
       expect( vagrantfile ).to match(/v.vm.provision 'shell', :path => '#{shell_path}'/)
     end
 
+    it "can make a Vagrantfile with optional shell provisioner with args" do
+      path = vagrant.instance_variable_get( :@vagrant_path )
+      allow( vagrant ).to receive( :randmac ).and_return( "0123456789" )
+
+      shell_path = '/path/to/shell/script.sh'
+      shell_args = 'arg1 arg2'
+      hosts = make_hosts({
+        :shell_provisioner => {
+          :path => shell_path,
+          :args => shell_args
+        }
+      }, 1)
+      vagrant.make_vfile( hosts, options )
+
+      vagrantfile = File.read( File.expand_path( File.join( path, "Vagrantfile")))
+      expect( vagrantfile ).to match(/v.vm.provision 'shell', :path => '#{shell_path}', :args => '#{shell_args}'/)
+    end
+
     it "raises an error if path is not set on shell_provisioner" do
       path = vagrant.instance_variable_get( :@vagrant_path )
       allow( vagrant ).to receive( :randmac ).and_return( "0123456789" )

--- a/spec/beaker/hypervisor/vagrant_spec.rb
+++ b/spec/beaker/hypervisor/vagrant_spec.rb
@@ -178,6 +178,43 @@ EOF
       expect( vagrantfile ).to match(/v.vm.synced_folder '\/valid', '\/valid', create: true/)
     end
 
+    it "can make a Vagrantfile with optional shell provisioner" do
+      path = vagrant.instance_variable_get( :@vagrant_path )
+      allow( vagrant ).to receive( :randmac ).and_return( "0123456789" )
+
+      shell_path = '/path/to/shell/script'
+      hosts = make_hosts({
+        :shell_provisioner => {
+          :path => shell_path
+        }
+      }, 1)
+      vagrant.make_vfile( hosts, options )
+
+      vagrantfile = File.read( File.expand_path( File.join( path, "Vagrantfile")))
+      expect( vagrantfile ).to match(/v.vm.provision 'shell', :path => '#{shell_path}'/)
+    end
+
+    it "raises an error if path is not set on shell_provisioner" do
+      path = vagrant.instance_variable_get( :@vagrant_path )
+      allow( vagrant ).to receive( :randmac ).and_return( "0123456789" )
+
+      hosts = make_hosts({:shell_provisioner => {}}, 1)
+      expect{ vagrant.make_vfile( hosts, options ) }.to raise_error RuntimeError, /No path defined for shell_provisioner or path empty/
+    end
+
+    it "raises an error if path is EMPTY on shell_provisioner" do
+      path = vagrant.instance_variable_get( :@vagrant_path )
+      allow( vagrant ).to receive( :randmac ).and_return( "0123456789" )
+
+      empty_shell_path = ''
+      hosts = make_hosts({
+        :shell_provisioner => {
+          :path => empty_shell_path
+        }
+      }, 1)
+      expect{ vagrant.make_vfile( hosts, options ) }.to raise_error RuntimeError, /No path defined for shell_provisioner or path empty/
+    end
+
     context "when generating a windows config" do
       before do
         path = vagrant.instance_variable_get( :@vagrant_path )


### PR DESCRIPTION
Currently beaker does not support WinRM connections to windows hosts.
To use beaker to provision and run tests on a Windows 2016 server using vagrant,
beaker uses SSH connection to connect to the box. This means that there should be a SSH server
configured on the windows box. This needs to happen before beaker starting to connect.

The only possible option in the context of vagrant is to use vagrant provision.

So this add `shell_provisioner` option on the beaker host file to allow running
a shell script using vagrant. This takes advantage of Vagrant WinRM setup.