### PR TITLE
remove audio of SUT with virtualbox

### DIFF
--- a/lib/beaker/hypervisor/vagrant_virtualbox.rb
+++ b/lib/beaker/hypervisor/vagrant_virtualbox.rb
@@ -25,9 +25,10 @@ class Beaker::VagrantVirtualbox < Beaker::Vagrant
 
   def self.provider_vfile_section(host, options)
     # Allow memory and CPUs to be set at a per node level or overall, and take the most specific setting
+    # Removing audio is a workaround of a virtualbox bug that gives error message : "The specified string / bytes buffer was to small"
     provider_section  = ""
     provider_section << "    v.vm.provider :virtualbox do |vb|\n"
-    provider_section << "      vb.customize ['modifyvm', :id, '--memory', '#{memsize(host,options)}', '--cpus', '#{cpus(host,options)}']\n"
+    provider_section << "      vb.customize ['modifyvm', :id, '--memory', '#{memsize(host,options)}', '--cpus', '#{cpus(host,options)}', '--audio', 'none']\n"
     provider_section << "      vb.vbguest.auto_update = false" if options[:vbguest_plugin] == 'disable'
 
     # Guest volume support

--- a/spec/beaker/hypervisor/vagrant_virtualbox_spec.rb
+++ b/spec/beaker/hypervisor/vagrant_virtualbox_spec.rb
@@ -27,7 +27,7 @@ describe Beaker::VagrantVirtualbox do
     vagrant.make_vfile( @hosts )
 
     vagrantfile = File.read( File.expand_path( File.join( path, 'Vagrantfile' )))
-    expect( vagrantfile ).to include( %Q{    v.vm.provider :virtualbox do |vb|\n      vb.customize ['modifyvm', :id, '--memory', '1024', '--cpus', '1']\n    end})
+    expect( vagrantfile ).to include( %Q{    v.vm.provider :virtualbox do |vb|\n      vb.customize ['modifyvm', :id, '--memory', '1024', '--cpus', '1', '--audio', 'none']\n    end})
   end
 
   it "can disable the vb guest plugin" do


### PR DESCRIPTION
 Some circumstances (not identified) cause Beaker runs to stop with following error message : 
```
daneel:/tmp/puppet-virtualbox$ RBENV_VERSION=2.5.1 BEAKER_IS_PE=no PUPPET_INSTALL_TYPE=agent BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_debug=yes bundle exec rake beaker:ubuntu-server-1804-x64
[... 8x ...]
Hypervisor for ubuntu-server-1804-x64 is vagrant
Beaker::Hypervisor, found some vagrant boxes to create
created Vagrantfile for VagrantHost ubuntu-server-1804-x64
Bringing machine 'ubuntu-server-1804-x64' up with 'virtualbox' provider...
==> ubuntu-server-1804-x64: Importing base box 'ubuntu/bionic64'...
Progress: 10%Progress: 90%==> ubuntu-server-1804-x64: Matching MAC address for NAT networking...
==> ubuntu-server-1804-x64: Checking if box 'ubuntu/bionic64' is up to date...
==> ubuntu-server-1804-x64: A newer version of the box 'ubuntu/bionic64' for provider 'virtualbox' is
==> ubuntu-server-1804-x64: available! You currently have version '20180717.1.0'. The latest is version
==> ubuntu-server-1804-x64: '20181114.1.0'. Run `vagrant box update` to update.
==> ubuntu-server-1804-x64: Setting the name of the VM: ubuntu-server-1804-x64yml_ubuntu-server-1804-x64_1542707627432_97414
==> ubuntu-server-1804-x64: Clearing any previously set network interfaces...
==> ubuntu-server-1804-x64: Preparing network interfaces based on configuration...
    ubuntu-server-1804-x64: Adapter 1: nat
    ubuntu-server-1804-x64: Adapter 2: hostonly
==> ubuntu-server-1804-x64: Forwarding ports...
    ubuntu-server-1804-x64: 22 (guest) => 2222 (host) (adapter 1)
==> ubuntu-server-1804-x64: Running 'pre-boot' VM customizations...
==> ubuntu-server-1804-x64: Booting VM...

An error occurred while loading ./spec/acceptance/01_virtualbox_spec.rb.
Failure/Error: require 'beaker-rspec'
RuntimeError:
  Failed to exec 'vagrant up'. Error was There was an error while executing `VBoxManage`, a CLI used by Vagrant
  for controlling VirtualBox. The command and stderr is shown below.
  
  Command: ["startvm", "a05bd452-ca6e-47cf-8b0c-0ac749d58b89", "--type", "headless"]
  
  Stderr: VBoxManage: error: The specified string / bytes buffer was to small. Specify a larger one and retry. (VERR_CFGM_NOT_ENOUGH_SPACE)
  VBoxManage: error: Details: code NS_ERROR_FAILURE (0x80004005), component ConsoleWrap, interface IConsole

```
It looks to be a bug in Virtualbox/VBoxManage. But, removing audio from SUT is enough to workaround. And IMO sound is not used on SUT during acceptance tests.

Can you consider to include this PR ?