### PR TITLE
Set RUBYOPT to an empty string for bundler

### DIFF
--- a/lib/beaker/hypervisor/vagrant.rb
+++ b/lib/beaker/hypervisor/vagrant.rb
@@ -224,7 +224,7 @@ module Beaker
       @vagrant_path = File.expand_path(File.join(File.basename(__FILE__), '..', '.vagrant', 'beaker_vagrant_files', File.basename(options[:hosts_file])))
       FileUtils.mkdir_p(@vagrant_path)
       @vagrant_file = File.expand_path(File.join(@vagrant_path, "Vagrantfile"))
-      @vagrant_env = { "RUBYLIB" => "" }
+      @vagrant_env = { "RUBYLIB" => "", "RUBYOPT" => "" }
     end
 
     def configure(opts = {})

--- a/spec/beaker/hypervisor/vagrant_spec.rb
+++ b/spec/beaker/hypervisor/vagrant_spec.rb
@@ -457,7 +457,7 @@ EOF
         allow( state ).to receive( :success? ).and_return( true )
         wait_thr.value = state
 
-        allow( Open3 ).to receive( :popen3 ).with( {"RUBYLIB"=>""}, 'vagrant', 'ssh-config', name ).and_return( [ "", out, "", wait_thr ])
+        allow( Open3 ).to receive( :popen3 ).with( {"RUBYLIB"=>"", "RUBYOPT"=>""}, 'vagrant', 'ssh-config', name ).and_return( [ "", out, "", wait_thr ])
 
         allow( file ).to receive( :path ).and_return( '/path/sshconfig' )
         allow( file ).to receive( :rewind ).and_return( true )


### PR DESCRIPTION
Similar to setting RUBYLIB to an empty string for BKR-511 my Fedora 28 machine also needs RUBYOPT set to an empty string to avoid bundler issues.