### PR TITLE
Call configure method of parent class.

### DIFF
--- a/lib/beaker/hypervisor/vagrant.rb
+++ b/lib/beaker/hypervisor/vagrant.rb
@@ -239,6 +239,7 @@ module Beaker
 
         set_all_ssh_config
       end
+      super
     end
 
     def provision(provider = nil)

--- a/spec/beaker/hypervisor/vagrant_spec.rb
+++ b/spec/beaker/hypervisor/vagrant_spec.rb
@@ -1,3 +1,4 @@
+require 'beaker/platform'
 require 'spec_helper'
 
 module Beaker
@@ -23,7 +24,8 @@ module Beaker
           :http => {:from => 10080, :to => 80},
           :ssl  => {:from => 4443,  :to => 443},
           :tomcat => {:from => 8080, :to => 8080}
-        }
+        },
+        :platform => Beaker::Platform.new('centos-8-x86_64')
       })
     end
 


### PR DESCRIPTION
Commit 8bcb1f8dafd overrides the configure method but this removes a number of important bootstrapping steps like enabling environment variables in the ssh session (for example, add_env_var stopped working because `PermitUserEnvironment` is no longer added to sshd_config).