### PR TITLE
(BKR-1553) Set PermitUserEnvironment

### DIFF
--- a/lib/beaker/hypervisor/vagrant.rb
+++ b/lib/beaker/hypervisor/vagrant.rb
@@ -166,6 +166,14 @@ module Beaker
         host.close
 
         set_ssh_config host, default_user
+
+        #allow the user to set the env
+        begin
+          host.ssh_permit_user_environment
+          host.close
+        rescue ArgumentError => e
+          @logger.debug("Failed to set SshPermitUserEnvironment. #{e}")
+        end
       end
 
       hack_etc_hosts @hosts, @options

--- a/spec/beaker/hypervisor/vagrant_spec.rb
+++ b/spec/beaker/hypervisor/vagrant_spec.rb
@@ -636,10 +636,11 @@ EOF
       before :each do
         expect( vagrant ).to receive( :vagrant_cmd ).with( "up" ).once
         @hosts.each do |host|
+          host[:platform] = 'windows'
           host_prev_name = host['user']
-          expect( vagrant ).to receive( :set_ssh_config ).with( host, 'vagrant' ).once
-          expect( vagrant ).not_to receive( :copy_ssh_to_root ).with( host, options ).once
-          expect( vagrant ).not_to receive( :set_ssh_config ).with( host, host_prev_name ).once
+          expect( vagrant ).not_to receive( :set_ssh_config ).with( host, 'vagrant' )
+          expect( vagrant ).not_to receive( :copy_ssh_to_root ).with( host, options )
+          expect( vagrant ).to receive( :set_ssh_config ).with( host, host_prev_name ).once
         end
         expect( vagrant ).to receive( :hack_etc_hosts ).with( @hosts, options ).once
       end

--- a/spec/beaker/hypervisor/vagrant_spec.rb
+++ b/spec/beaker/hypervisor/vagrant_spec.rb
@@ -60,7 +60,7 @@ Vagrant.configure("2") do |c|
     v.vm.network :forwarded_port, guest: 443, host: 4443
     v.vm.network :forwarded_port, guest: 8080, host: 8080
     v.vm.provider :virtualbox do |vb|
-      vb.customize ['modifyvm', :id, '--memory', '1024', '--cpus', '1']
+      vb.customize ['modifyvm', :id, '--memory', '1024', '--cpus', '1', '--audio', 'none']
     end
   end
   c.vm.define 'vm2' do |v|
@@ -75,7 +75,7 @@ Vagrant.configure("2") do |c|
     v.vm.network :forwarded_port, guest: 443, host: 4443
     v.vm.network :forwarded_port, guest: 8080, host: 8080
     v.vm.provider :virtualbox do |vb|
-      vb.customize ['modifyvm', :id, '--memory', '1024', '--cpus', '1']
+      vb.customize ['modifyvm', :id, '--memory', '1024', '--cpus', '1', '--audio', 'none']
     end
   end
   c.vm.define 'vm3' do |v|
@@ -90,7 +90,7 @@ Vagrant.configure("2") do |c|
     v.vm.network :forwarded_port, guest: 443, host: 4443
     v.vm.network :forwarded_port, guest: 8080, host: 8080
     v.vm.provider :virtualbox do |vb|
-      vb.customize ['modifyvm', :id, '--memory', '1024', '--cpus', '1']
+      vb.customize ['modifyvm', :id, '--memory', '1024', '--cpus', '1', '--audio', 'none']
     end
   end
 end
@@ -295,7 +295,7 @@ EOF
 
       generated_file = File.read( File.expand_path( File.join( path, "Vagrantfile") ) )
 
-      match = generated_file.match(/vb.customize \['modifyvm', :id, '--memory', 'hello!', '--cpus', '1'\]/)
+      match = generated_file.match(/vb.customize \['modifyvm', :id, '--memory', 'hello!', '--cpus', '1', '--audio', 'none'\]/)
 
       expect( match ).to_not be nil
 
@@ -309,7 +309,7 @@ EOF
 
       generated_file = File.read( File.expand_path( File.join( path, "Vagrantfile") ) )
 
-      match = generated_file.match(/vb.customize \['modifyvm', :id, '--memory', '1024', '--cpus', 'goodbye!'\]/)
+      match = generated_file.match(/vb.customize \['modifyvm', :id, '--memory', '1024', '--cpus', 'goodbye!', '--audio', 'none'\]/)
 
       expect( match ).to_not be nil
 


### PR DESCRIPTION
Beaker relies on setting the environment via ~/.ssh/environment. By using this helper we ensure the path is set correctly and we can execute puppet.