### PR TITLE
Use winrm communicator for Windows

### DIFF
--- a/lib/beaker/hypervisor/vagrant.rb
+++ b/lib/beaker/hypervisor/vagrant.rb
@@ -102,6 +102,7 @@ module Beaker
           v_file << "    v.vm.network :forwarded_port, guest: 3389, host: 3389, id: 'rdp', auto_correct: true\n"
           v_file << "    v.vm.network :forwarded_port, guest: 5985, host: 5985, id: 'winrm', auto_correct: true\n"
           v_file << "    v.vm.guest = :windows\n"
+          v_file << "    v.vm.communicator = 'winrm'\n"
         end
 
         if /osx/i.match(host['platform'])

--- a/spec/beaker/hypervisor/vagrant_spec.rb
+++ b/spec/beaker/hypervisor/vagrant_spec.rb
@@ -258,6 +258,10 @@ EOF
         expect( @generated_file ).to match /v.vm.guest = :windows/
       end
 
+      it 'configures the guest type to use winrm' do
+        expect( @generated_file ).to match /v.vm.communicator = 'winrm'/
+      end
+
       it 'sets a non-default memsize' do
         expect( @generated_file ).to match /'--memory', '2048',/
       end


### PR DESCRIPTION
Without this change vagrant is trying to SSH to Windows:

```
==> windows-server-amd64: Waiting for machine to boot. This may take a few minutes...
    windows-server-amd64: SSH address: 127.0.0.1:2200
    windows-server-amd64: SSH username: vagrant
    windows-server-amd64: SSH auth method: private key
```

After this change

```
==> windows-server-amd64: Waiting for machine to boot. This may take a few minutes...
    windows-server-amd64: WinRM address: 127.0.0.1:5985
    windows-server-amd64: WinRM username: vagrant
    windows-server-amd64: WinRM execution_time_limit: PT2H
    windows-server-amd64: WinRM transport: negotiate
==> windows-server-amd64: Machine booted and ready!
```