### PR TITLE
Never use QEMU session with libvirt

### DIFF
--- a/lib/beaker/hypervisor/vagrant_libvirt.rb
+++ b/lib/beaker/hypervisor/vagrant_libvirt.rb
@@ -23,6 +23,7 @@ class Beaker::VagrantLibvirt < Beaker::Vagrant
     "    v.vm.provider :libvirt do |node|\n" +
       "      node.cpus = #{cpus(host, options)}\n" +
       "      node.memory = #{memsize(host, options)}\n" +
+      "      node.qemu_use_session = false\n" +
       build_options_str(options) +
       "    end\n"
   end


### PR DESCRIPTION
Fedora 30 started to default to the session, but the way beaker-vagrant sets up networking is incompatible. Setting up private networks QEMU requires root privileges.

https://github.com/vagrant-libvirt/vagrant-libvirt#qemu-session-support

Note that it's not possible to set this via options because those are always written as strings.