### PR TITLE
Fix WinRM error message matching

### DIFF
--- a/lib/beaker/hypervisor/vagrant.rb
+++ b/lib/beaker/hypervisor/vagrant.rb
@@ -303,7 +303,7 @@ module Beaker
             end
           }
         rescue => e
-          if e =~ /WinRM/m
+          if e.to_s =~ /WinRM/m
             sleep(10)
 
             retry if (retries += 1) < 6


### PR DESCRIPTION
The error message needed to be converted to a String prior to matching
otherwise the logic was ineffective.