### PR TITLE
(BKR-1635) Fix and document `natdns`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+---
+os:
+  - linux
+before_install:
+  - gem update --system 2.2.1
+  - gem --version
+language: ruby
+script: "bundle exec rake test:spec:run"
+notifications:
+  email: false
+rvm:
+  - 2.6
+  - 2.5
+  - 2.4

--- a/docs/vagrant.md
+++ b/docs/vagrant.md
@@ -1,5 +1,21 @@
 # Vagrant
 
+<!-- vim-markdown-toc GFM -->
+
+  * [Getting Started](#getting-started)
+    * [Requirements](#requirements)
+    * [Setup a Vagrant Hosts File](#setup-a-vagrant-hosts-file)
+* [Vagrant-Specific Hosts File Settings](#vagrant-specific-hosts-file-settings)
+    * [Running With a GUI](#running-with-a-gui)
+    * [Mounting Local Folders](#mounting-local-folders)
+    * [Forwarding Ports to Guest](#forwarding-ports-to-guest)
+    * [Volumes Support](#volumes-support)
+    * [Adding vagrant shell provisioner](#adding-vagrant-shell-provisioner)
+    * [Using the host's resolver as a DNS proxy in NAT mode (virtualbox only)](#using-the-hosts-resolver-as-a-dns-proxy-in-nat-mode-virtualbox-only)
+* [vagrant plugins](#vagrant-plugins)
+
+<!-- vim-markdown-toc -->
+
 Vagrant's slogan is "development environments made easy". Vagrant provides an
 abstraction on top of a VM or cloud provider that allows you to manage
 hosts and their provisioning. <https://www.vagrantup.com/>.
@@ -211,8 +227,30 @@ When using the Vagrant Hypervisor, beaker can create the Vagrantfile with a shel
 
 In the above, beaker will create a Vagrantfile which runs the above shell script on the Agent guest.
 
+### Using the host's resolver as a DNS proxy in NAT mode (virtualbox only)
+
+When using the Vagrant hypervisor with the virtualbox provider, beaker can
+configure the VirtualBox NAT engine's DHCP sever to proxy DNS queries through
+to the host's resolver using the `natdns` setting in the nodeset file.
+
+**Example hosts file**
+
+    HOSTS:
+      el7-server:
+        roles:
+          - default
+        platform: el-7-x86_64
+        box: centos/7
+        hypervisor: vagrant
+        natdns: on
+        yum_repos:
+          epel:
+            mirrorlist: 'https://mirrors.fedoraproject.org/mirrorlist?repo=epel-7&arch=$basearch&country=us'
+            gpgkeys:
+              - https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-$releasever
+
 # vagrant plugins #
 
-You can check more information for some suported vagrant plugins:
+You can check more information for some supported vagrant plugins:
 
  - [vagrant-libvirt](vagrant_libvirt.md)

--- a/lib/beaker/hypervisor/vagrant_virtualbox.rb
+++ b/lib/beaker/hypervisor/vagrant_virtualbox.rb
@@ -63,15 +63,15 @@ class Beaker::VagrantVirtualbox < Beaker::Vagrant
       end
     end
 
-    provider_section << "      vb.customize [\"modifyvm\", :id, \"--ioapic\", \"on\"]\n" unless host['ioapic'].nil?
+    provider_section << "      vb.customize ['modifyvm', :id, '--ioapic', 'on']\n" unless host['ioapic'].nil?
 
-    provider_section << "      vb.customize [\"modifyvm\", :id, \"--natdnshostresolver1\", \"on\"]\n" unless host['natdns'].nil?
+    provider_section << "      vb.customize ['modifyvm', :id, '--natdnshostresolver1', 'on']\n" unless host['natdns'].nil?
 
-    provider_section << "      vb.customize [\"modifyvm\", :id, \"--natdnsproxy1\", \"on\"]\n" unless host['natdns'].nil?
+    provider_section << "      vb.customize ['modifyvm', :id, '--natdnsproxy1', 'on']\n" unless host['natdns'].nil?
 
     provider_section << "      vb.gui = true\n" unless host['vb_gui'].nil?
 
-    provider_section << "      [\"modifyvm\", :id, \"--cpuidset\", \"1\",\"000206a7\",\"02100800\",\"1fbae3bf\",\"bfebfbff\"\]" if /osx/i.match(host['platform'])
+    provider_section << "      ['modifyvm', :id, '--cpuidset', '1','000206a7','02100800','1fbae3bf','bfebfbff'\]" if /osx/i.match(host['platform'])
 
     if host['disk_path']
       unless File.exist?(host['disk_path'])

--- a/lib/beaker/hypervisor/vagrant_virtualbox.rb
+++ b/lib/beaker/hypervisor/vagrant_virtualbox.rb
@@ -65,9 +65,9 @@ class Beaker::VagrantVirtualbox < Beaker::Vagrant
 
     provider_section << "      vb.customize [\"modifyvm\", :id, \"--ioapic\", \"on\"]\n" unless host['ioapic'].nil?
 
-    provider_section << "      vb.customize [\"modifyvm\", :id, \"--natdnshostresolver1\", \"#{host['natdns']}\"]\n" unless host['natdns'].nil?
+    provider_section << "      vb.customize [\"modifyvm\", :id, \"--natdnshostresolver1\", \"on\"]\n" unless host['natdns'].nil?
 
-    provider_section << "      vb.customize [\"modifyvm\", :id, \"--natdnsproxy1\", \"#{host['natdns']}\"]\n" unless host['natdns'].nil?
+    provider_section << "      vb.customize [\"modifyvm\", :id, \"--natdnsproxy1\", \"on\"]\n" unless host['natdns'].nil?
 
     provider_section << "      vb.gui = true\n" unless host['vb_gui'].nil?
 

--- a/lib/beaker/hypervisor/vagrant_virtualbox.rb
+++ b/lib/beaker/hypervisor/vagrant_virtualbox.rb
@@ -71,7 +71,7 @@ class Beaker::VagrantVirtualbox < Beaker::Vagrant
 
     provider_section << "      vb.gui = true\n" unless host['vb_gui'].nil?
 
-    provider_section << "      ['modifyvm', :id, '--cpuidset', '1','000206a7','02100800','1fbae3bf','bfebfbff'\]" if /osx/i.match(host['platform'])
+    provider_section << "      vb.customize ['modifyvm', :id, '--cpuidset', '1','000206a7','02100800','1fbae3bf','bfebfbff']\n" if /osx/i.match(host['platform'])
 
     if host['disk_path']
       unless File.exist?(host['disk_path'])

--- a/spec/beaker/hypervisor/vagrant_virtualbox_spec.rb
+++ b/spec/beaker/hypervisor/vagrant_virtualbox_spec.rb
@@ -3,6 +3,10 @@ require 'spec_helper'
 describe Beaker::VagrantVirtualbox do
   let( :options ) { make_opts.merge({ :hosts_file => 'sample.cfg', 'logger' => double().as_null_object }) }
   let( :vagrant ) { Beaker::VagrantVirtualbox.new( @hosts, options ) }
+  let(:vagrantfile_path) do
+    path = vagrant.instance_variable_get( :@vagrant_path )
+    File.expand_path( File.join( path, 'Vagrantfile' ))
+  end
 
   before :each do
     @hosts = make_hosts()
@@ -49,6 +53,15 @@ describe Beaker::VagrantVirtualbox do
 
     vagrantfile = File.read( File.expand_path( File.join( path, 'Vagrantfile' )))
     expect( vagrantfile ).to include( " vb.customize ['modifyvm', :id, '--ioapic', 'on']")
+  end
+
+  it "can enable NAT DNS on hosts" do
+    hosts = make_hosts({:natdns => 'on'},1)
+    vagrant.make_vfile( hosts )
+    vagrantfile = File.read( vagrantfile_path )
+
+    expect( vagrantfile ).to include( " vb.customize ['modifyvm', :id, '--natdnshostresolver1', 'on']")
+    expect( vagrantfile ).to include( " vb.customize ['modifyvm', :id, '--natdnsproxy1', 'on']")
   end
 
   it "correctly provisions storage with the USB controller" do

--- a/spec/beaker/hypervisor/vagrant_virtualbox_spec.rb
+++ b/spec/beaker/hypervisor/vagrant_virtualbox_spec.rb
@@ -41,14 +41,14 @@ describe Beaker::VagrantVirtualbox do
 
   end
 
-  it "can enable ioapic(multiple cores) on hosts" do 
+  it "can enable ioapic(multiple cores) on hosts" do
     path = vagrant.instance_variable_get( :@vagrant_path )
     hosts = make_hosts({:ioapic => 'true'},1)
 
     vagrant.make_vfile( hosts )
 
     vagrantfile = File.read( File.expand_path( File.join( path, 'Vagrantfile' )))
-    expect( vagrantfile ).to include( %Q{ vb.customize ["modifyvm", :id, "--ioapic", "on"]})
+    expect( vagrantfile ).to include( " vb.customize ['modifyvm', :id, '--ioapic', 'on']")
   end
 
   it "correctly provisions storage with the USB controller" do
@@ -57,10 +57,10 @@ describe Beaker::VagrantVirtualbox do
 
     vagrant.make_vfile( hosts )
     vagrantfile = File.read( File.expand_path( File.join( path, 'Vagrantfile' )))
-    expect( vagrantfile ).to include(%Q{ vb.customize ['modifyvm', :id, '--usb', 'on']})
-    expect( vagrantfile ).to include(%Q{ vb.customize ['storagectl', :id, '--name', 'Beaker USB Controller', '--add', 'usb', '--portcount', '8', '--controller', 'USB', '--bootable', 'off']})
-    expect( vagrantfile ).to include(%Q{ vb.customize ['createhd', '--filename', 'vm1-test_disk.vdi', '--size', '5120']})
-    expect( vagrantfile ).to include(%Q{ vb.customize ['storageattach', :id, '--storagectl', 'Beaker USB Controller', '--port', '0', '--device', '0', '--type', 'hdd', '--medium', 'vm1-test_disk.vdi']})
+    expect( vagrantfile ).to include(" vb.customize ['modifyvm', :id, '--usb', 'on']")
+    expect( vagrantfile ).to include(" vb.customize ['storagectl', :id, '--name', 'Beaker USB Controller', '--add', 'usb', '--portcount', '8', '--controller', 'USB', '--bootable', 'off']")
+    expect( vagrantfile ).to include(" vb.customize ['createhd', '--filename', 'vm1-test_disk.vdi', '--size', '5120']")
+    expect( vagrantfile ).to include(" vb.customize ['storageattach', :id, '--storagectl', 'Beaker USB Controller', '--port', '0', '--device', '0', '--type', 'hdd', '--medium', 'vm1-test_disk.vdi']")
   end
 
   it "correctly provisions storage with the LSILogic controller" do
@@ -69,9 +69,9 @@ describe Beaker::VagrantVirtualbox do
 
     vagrant.make_vfile( hosts )
     vagrantfile = File.read( File.expand_path( File.join( path, 'Vagrantfile' )))
-    expect( vagrantfile ).to include(%Q{ vb.customize ['storagectl', :id, '--name', 'Beaker LSILogic Controller', '--add', 'scsi', '--portcount', '16', '--controller', 'LSILogic', '--bootable', 'off']})
-    expect( vagrantfile ).to include(%Q{ vb.customize ['createhd', '--filename', 'vm1-test_disk.vdi', '--size', '5120']})
-    expect( vagrantfile ).to include(%Q{ vb.customize ['storageattach', :id, '--storagectl', 'Beaker LSILogic Controller', '--port', '0', '--device', '0', '--type', 'hdd', '--medium', 'vm1-test_disk.vdi']})
+    expect( vagrantfile ).to include(" vb.customize ['storagectl', :id, '--name', 'Beaker LSILogic Controller', '--add', 'scsi', '--portcount', '16', '--controller', 'LSILogic', '--bootable', 'off']")
+    expect( vagrantfile ).to include(" vb.customize ['createhd', '--filename', 'vm1-test_disk.vdi', '--size', '5120']")
+    expect( vagrantfile ).to include(" vb.customize ['storageattach', :id, '--storagectl', 'Beaker LSILogic Controller', '--port', '0', '--device', '0', '--type', 'hdd', '--medium', 'vm1-test_disk.vdi']")
   end
 
   it "correctly provisions storage with the default controller" do
@@ -80,8 +80,8 @@ describe Beaker::VagrantVirtualbox do
 
     vagrant.make_vfile( hosts )
     vagrantfile = File.read( File.expand_path( File.join( path, 'Vagrantfile' )))
-    expect( vagrantfile ).to include(%Q{ vb.customize ['storagectl', :id, '--name', 'Beaker IntelAHCI Controller', '--add', 'sata', '--portcount', '2', '--controller', 'IntelAHCI', '--bootable', 'off']})
-    expect( vagrantfile ).to include(%Q{ vb.customize ['createhd', '--filename', 'vm1-test_disk.vdi', '--size', '5120']})
-    expect( vagrantfile ).to include(%Q{ vb.customize ['storageattach', :id, '--storagectl', 'Beaker IntelAHCI Controller', '--port', '0', '--device', '0', '--type', 'hdd', '--medium', 'vm1-test_disk.vdi']})
+    expect( vagrantfile ).to include(" vb.customize ['storagectl', :id, '--name', 'Beaker IntelAHCI Controller', '--add', 'sata', '--portcount', '2', '--controller', 'IntelAHCI', '--bootable', 'off']")
+    expect( vagrantfile ).to include(" vb.customize ['createhd', '--filename', 'vm1-test_disk.vdi', '--size', '5120']")
+    expect( vagrantfile ).to include(" vb.customize ['storageattach', :id, '--storagectl', 'Beaker IntelAHCI Controller', '--port', '0', '--device', '0', '--type', 'hdd', '--medium', 'vm1-test_disk.vdi']")
   end
 end


### PR DESCRIPTION
Before this patch, the (undocumented) Virtualbox host setting `natdns` would break Vagrant by adding the settings 'natdnshostresolver1' and 'natdnsproxy1' with the invalid value `"true"`, regardless of the text 'natdns' was set to for that host.  The valid value Virtualbox expects for these settings is `"on"`: https://www.virtualbox.org/manual/ch09.html#nat-adv-dns .

This patch fixes the issue by:
* Setting `natdnshostresolver1` and `natdnsproxy1` to "on" instead of "true".
* Adding spec tests for `natdns` 
* Documenting `natdns` in docs/vagrant.md

The patch also includes several other minor improvements:
* Adds hyperlinked TOC to docs/vagrant.md and fixes a typo
* Reduces noisy quote-escape syntax by using single-quotes in the Vagrantfile
* Fixes broken syntax in cpuidset for osx (noticed after reducing quote-escapes)
* Adds Travis CI pipeline to run spec tests (modeled on puppetlabs/beaker)

