### PR TITLE
(BKR-1423) Fix SSH settings in nodesets

### DIFF
--- a/lib/beaker/hypervisor/vagrant.rb
+++ b/lib/beaker/hypervisor/vagrant.rb
@@ -201,7 +201,8 @@ module Beaker
 
         f.write(ssh_config)
         f.rewind
-        host['ssh'] = {:config => f.path()}
+
+        host['ssh'] = host['ssh'].merge(Net::SSH.configuration_for(host['ip'], f.path))
         host['user'] = user
         @temp_files << f
     end

--- a/lib/beaker/hypervisor/vagrant.rb
+++ b/lib/beaker/hypervisor/vagrant.rb
@@ -202,6 +202,7 @@ module Beaker
         f.write(ssh_config)
         f.rewind
 
+        host[:vagrant_ssh_config] = f.path
         host['ssh'] = host['ssh'].merge(Net::SSH.configuration_for(host['ip'], f.path))
         host['user'] = user
         @temp_files << f

--- a/spec/beaker/hypervisor/vagrant_spec.rb
+++ b/spec/beaker/hypervisor/vagrant_spec.rb
@@ -484,7 +484,8 @@ EOF
         expect( file ).to receive( :write ).with("Host ip.address.for.#{name}\n        HostName 127.0.0.1\n        User root\n        Port 2222\n        UserKnownHostsFile /dev/null\n        StrictHostKeyChecking no\n        PasswordAuthentication no\n        IdentityFile /home/root/.vagrant.d/insecure_private_key\n        IdentitiesOnly no")
 
         vagrant.set_ssh_config( host, 'root' )
-        expect( host['ssh'] ).to be === { :config => file.path }
+        expect( host[:vagrant_ssh_config] ).to be === '/path/sshconfig'
+        expect( host['ssh'][:config]).to be === false
         expect( host['user']).to be === 'root'
       end
 
@@ -498,7 +499,8 @@ EOF
           expect( file ).to receive( :write ).with("Host ip.address.for.#{name}\n        HostName 127.0.0.1\n        User root\n        Port 2222\n        UserKnownHostsFile /dev/null\n        StrictHostKeyChecking no\n        PasswordAuthentication no\n        IdentityFile /home/root/.vagrant.d/insecure_private_key\n        IdentitiesOnly yes")
 
           vagrant.set_ssh_config( host, 'root' )
-          expect( host['ssh'] ).to be === { :config => file.path }
+          expect( host[:vagrant_ssh_config] ).to be === '/path/sshconfig'
+          expect( host['ssh'][:config]).to be === false
           expect( host['user']).to be === 'root'
         end
       end


### PR DESCRIPTION
Allow SSH settings from nodesets to propagate properly into the host's
SSH configuration.

BKR-1423 #close