### PR TITLE
Fix simultaneous runs with the libvirt hypervisor

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,3 +1,4 @@
 --format documentation
 --color
 --tty
+--fail-fast

--- a/lib/beaker/hypervisor/vagrant_libvirt.rb
+++ b/lib/beaker/hypervisor/vagrant_libvirt.rb
@@ -16,6 +16,12 @@ class Beaker::VagrantLibvirt < Beaker::Vagrant
   end
 
   def provision(provider = 'libvirt')
+    # This needs to be unique for every system with the same hostname but does
+    # not affect VirtualBox
+    vagrant_path_digest = Digest::SHA256.hexdigest(@vagrant_path)
+    @vagrant_path = @vagrant_path + '_' + vagrant_path_digest[0..2] + vagrant_path_digest[-3..-1]
+    @vagrant_file = File.expand_path(File.join(@vagrant_path, "Vagrantfile"))
+
     super
   end
 

--- a/spec/beaker/hypervisor/vagrant_spec.rb
+++ b/spec/beaker/hypervisor/vagrant_spec.rb
@@ -29,11 +29,11 @@ module Beaker
       })
     end
 
-    it "stores the vagrant file in $WORKINGDIR/.vagrant/beaker_vagrant_files/sample.cfg" do
+    it "stores the vagrant file in $WORKINGDIR/.vagrant/beaker_vagrant_files/beaker_sample.cfg" do
       allow( vagrant ).to receive( :randmac ).and_return( "0123456789" )
       path = vagrant.instance_variable_get( :@vagrant_path )
 
-      expect( path ).to be === File.join(Dir.pwd, '.vagrant', 'beaker_vagrant_files', 'sample.cfg')
+      expect( path ).to be === File.join(Dir.pwd, '.vagrant', 'beaker_vagrant_files', 'beaker_sample.cfg')
 
     end
 


### PR DESCRIPTION
Previously, if any two test runs occurred where the systems had identical
hostnames, then one of the runs would fail indicating that there was a
domain conflict.

This patch ensures that a unique name is created for each run when using
the `libvirt` provider.

Additionally, the string `beaker_` is prepended to the path name so that
it is easier to find your systems when large numbers of VMs are running
at the same time.

It also chooses a different base network when using `libvirt` vs
anything else so that users can use both VirtualBox and `libvirt`
simultaneously.